### PR TITLE
Make vars dynamic. Fixes #65.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,23 +43,20 @@
         <dl class="info-headings">
           <div>
             <dt>Data Gathered Since</dt>
-              <!-- @todo get date-start from store -->
-            <dd id="date-start">
-              <time datetime="2017-06-13T11:00">June 13, 2017</time>
+            <dd>
+              <time id="data-gathered-since" datetime="2017-06-13T11:00"></time>
             </dd>
           </div>
           <div>
             <dt>You Have Visited</dt>
-            <!-- @todo get num-sites-visited from store -->
             <dd>
-              <var id="num-sites-visited">6</var> Sites
+              <var id="num-sites-visited">0</var> Sites
             </dd>
           </div>
           <div>
             <dt>You Have Connected With</dt>
-            <!-- @todo get num-third-parties from store -->
             <dd>
-              <var id="num-third-parties">16</var> Third Party Sites
+              <var id="num-third-parties">0</var> Third Party Sites
             </dd>
           </div>
         </dl>

--- a/index.html
+++ b/index.html
@@ -44,19 +44,19 @@
           <div>
             <dt>Data Gathered Since</dt>
             <dd>
-              <time id="data-gathered-since" datetime="2017-06-13T11:00"></time>
+              <time id="data-gathered-since" datetime=""></time>
             </dd>
           </div>
           <div>
             <dt>You Have Visited</dt>
             <dd>
-              <var id="num-sites-visited">0</var> Sites
+              <var id="num-first-parties"></var>
             </dd>
           </div>
           <div>
             <dt>You Have Connected With</dt>
             <dd>
-              <var id="num-third-parties">0</var> Third Party Sites
+              <var id="num-third-parties"></var>
             </dd>
           </div>
         </dl>

--- a/js/capture.js
+++ b/js/capture.js
@@ -135,7 +135,7 @@ const capture = {
         target: targetUrl.hostname,
         origin: originUrl.hostname,
         requestTime: response.timeStamp,
-        firstParty: 0
+        firstParty: false
       };
       await store.setThirdParty(
         firstPartyUrl.hostname,
@@ -151,7 +151,8 @@ const capture = {
     if (tab.status === 'complete' && await this.shouldStore(tab)) {
       const data = {
         faviconUrl: tab.favIconUrl,
-        firstParty: 1
+        firstParty: true,
+        requestTime: Date.now()
       };
       await store.setFirstParty(documentUrl.hostname, data);
     }

--- a/js/capture.js
+++ b/js/capture.js
@@ -135,7 +135,7 @@ const capture = {
         target: targetUrl.hostname,
         origin: originUrl.hostname,
         requestTime: response.timeStamp,
-        firstParty: false
+        firstParty: 0
       };
       await store.setThirdParty(
         firstPartyUrl.hostname,
@@ -151,7 +151,7 @@ const capture = {
     if (tab.status === 'complete' && await this.shouldStore(tab)) {
       const data = {
         faviconUrl: tab.favIconUrl,
-        firstParty: true
+        firstParty: 1
       };
       await store.setFirstParty(documentUrl.hostname, data);
     }

--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -1,6 +1,6 @@
 const lightbeam = {
   websites: {},
-  dataGatheredSince: '',
+  dataGatheredSince: null,
   numFirstParties: 0,
   numThirdParties: 0,
 
@@ -27,45 +27,56 @@ const lightbeam = {
   // Called from init() (isFirstParty = undefined)
   // and redraw() (isFirstParty = true or false).
   async updateVars(isFirstParty) {
-    const numFirstParties = document.getElementById('num-first-parties');
-    const numThirdParties = document.getElementById('num-third-parties');
 
     // initialize dynamic vars from storage
     if (!this.dataGatheredSince) {
       const { dateStr, fullDateTime } = await this.getDataGatheredSince();
       this.dataGatheredSince = dateStr;
-      const dataGatheredSince = document.getElementById('data-gathered-since');
-      dataGatheredSince.textContent = this.dataGatheredSince;
-      dataGatheredSince.setAttribute('datetime', fullDateTime);
+      const dataGatheredSinceElement
+        = document.getElementById('data-gathered-since');
+      dataGatheredSinceElement.textContent = this.dataGatheredSince || '';
+      dataGatheredSinceElement.setAttribute('datetime', fullDateTime || '');
     }
     if (isFirstParty === undefined) {
       this.numFirstParties = await this.getNumFirstParties();
-      numFirstParties.textContent
-        = (this.numFirstParties === 0) ? '' : `${this.numFirstParties} Sites`;
+      this.setPartyVar('firstParty');
       this.numThirdParties = await this.getNumThirdParties();
-      numThirdParties.textContent
-        = (this.numThirdParties === 0) ? ''
-          : `${this.numThirdParties} Third Party Sites`;
+      this.setPartyVar('thirdParty');
       return;
     }
 
     // update on redraw
     if (isFirstParty) {
       this.numFirstParties++;
-      numFirstParties.textContent
-        = (this.numFirstParties === 0) ? '' : `${this.numFirstParties} Sites`;
+      this.setPartyVar('firstParty');
     } else {
       this.numThirdParties++;
-      numThirdParties.textContent
-        = (this.numThirdParties === 0) ? ''
-          : `${this.numThirdParties} Third Party Sites`;
+      this.setPartyVar('thirdParty');
+    }
+  },
+
+  // Updates dynamic variable values in the page
+  setPartyVar(party) {
+    const numFirstPartiesElement = document.getElementById('num-first-parties');
+    const numThirdPartiesElement = document.getElementById('num-third-parties');
+    if (party === 'firstParty') {
+      if (this.numFirstParties === 0) {
+        numFirstPartiesElement.textContent = '';
+      } else {
+        numFirstPartiesElement.textContent = `${this.numFirstParties} Sites`;
+      }
+    } else if (this.numThirdParties === 0) {
+      numThirdPartiesElement.textContent = '';
+    } else {
+      const str = `${this.numThirdParties} Third Party Sites`;
+      numThirdPartiesElement.textContent = str;
     }
   },
 
   async getDataGatheredSince() {
     const firstRequestUnixTime = await storeChild.getFirstRequestTime();
     if (!firstRequestUnixTime) {
-      return '';
+      return null;
     }
     // reformat unix time
     let fullDateTime = new Date(firstRequestUnixTime);


### PR DESCRIPTION
Added a few new methods to lightbeam.js and store.js to fetch these values from storage to initialize them, and then increment numVisitedSites and numThirdParties when appropriate on each redraw() in lightbeam.js.

It should be noted that for some reason [Dexie filtering does not support boolean values](http://dexie.org/docs/WhereClause/WhereClause.equals().html) for primary keys or indices, so I had to convert the `firstParty` and `isVisible` keys to use `0` for `false` and `1` for `true`...