### PR TITLE
Address first parties as third parties. Fixes #110.

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -296,7 +296,8 @@ const store = {
     // and the third party is visible (i.e. not allowlisted)
     if (!this.isFirstPartyLinkedToThirdParty(firstParty, target)) {
       if (!this.isVisibleThirdParty(thirdParty)) {
-        if (this.onAllowList(origin, target)) {
+        if (this.onAllowList(origin, target)
+          && !this.isAlsoAFirstParty(thirdParty)) {
           // hide third party
           thirdParty['isVisible'] = false;
         } else {
@@ -320,6 +321,10 @@ const store = {
     // merge data with thirdParty
     // @todo restructure storage to use data from capture for graph filtering
     for (const key in data) {
+      if (key ==='firstParty' && this.isAlsoAFirstParty(thirdParty)) {
+        // third parties that are already a first party stay a first party
+        data[key] = true;
+      }
       thirdParty[key] = data[key];
     }
 
@@ -343,6 +348,10 @@ const store = {
       return false;
     }
     return true;
+  },
+
+  isAlsoAFirstParty(thirdParty) {
+    return thirdParty.firstParty;
   },
 
   async addFirstPartyLink(firstPartyHostname, thirdPartyHostname) {


### PR DESCRIPTION
If a first party site later becomes a third party site, keep the firstParty key set to true and do not set isVisible to false, even if the site is on the allowlist as a third party. Added a new method 'isAlsoAThirdParty' to check this.

Before:
![screen shot 2017-08-25 at 12 44 20 pm](https://user-images.githubusercontent.com/17437436/29732403-52116ebe-899d-11e7-8d65-a0236130b787.png)

After:
![screen shot 2017-08-25 at 1 49 35 pm](https://user-images.githubusercontent.com/17437436/29732408-57b7ecf8-899d-11e7-8628-2f89321b150e.png)

@jonathanKingston , I have no known questions; so ready for you to take a look. :)
