### PR TITLE
Treat data with more consistency #177 possibly #179 and issues with #110

### DIFF
--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -189,7 +189,7 @@ const lightbeam = {
     let links = [];
     for (const website in this.websites) {
       const site = this.websites[website];
-      if (site.firstParty) {
+      if (site.thirdParties) {
         const thirdPartyLinks = site.thirdParties.map((thirdParty) => {
           return {
             source: website,
@@ -236,7 +236,7 @@ const lightbeam = {
       this.websites[data.hostname] = data;
       this.updateVars(data.firstParty);
     }
-    if (!data.firstParty) {
+    if (data.firstPartyHostnames) {
       // if we have the first parties make the link if they don't exist
       data.firstPartyHostnames.forEach((firstPartyHostname) => {
         if (this.websites[firstPartyHostname]) {


### PR DESCRIPTION
Changes include:
- Ensuring modified data that is stored gets passed back in update calls
- Inbound, outbound data munging to be the same shape (I think there are some bits missing to this)
- Ensures we draw the graph based on the thirdParties and firstParties keys rather than what type the node is
- Merges data for isVisible and firstParty so they never go from true to false after being set
- Fixes race condition where tp fires before fp causing a broken fp node.