### PR TITLE
Fix TypeError for a null return value in lightbeam.getDataGatheredSince

### DIFF
--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -31,6 +31,9 @@ const lightbeam = {
     // initialize dynamic vars from storage
     if (!this.dataGatheredSince) {
       const { dateStr, fullDateTime } = await this.getDataGatheredSince();
+      if (!dateStr) {
+        return;
+      }
       this.dataGatheredSince = dateStr;
       const dataGatheredSinceElement
         = document.getElementById('data-gathered-since');


### PR DESCRIPTION
If storage is empty, just exit the method to update the dynamic vars.