### PR TITLE
Properly munge inbound data in all cases. Fixes #187.

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -141,6 +141,9 @@ const store = {
   },
 
   async _write(website) {
+    for (const key in website) {
+      website[key] = this.mungeDataInbound(key, website[key]);
+    }
     return await this.db.websites.put(website);
   },
 
@@ -239,7 +242,7 @@ const store = {
     }
 
     for (const key in data) {
-      const value = this.mungeDataInbound(key, data[key]);
+      const value = data[key];
       switch (key) {
         case 'requestTime':
           // store first and last request times for clearing data every X days
@@ -252,6 +255,7 @@ const store = {
         case 'isVisible':
           if ('isVisible' in website
               && website.isVisible === true) {
+            // once a website is visible, it will always be visible
             break;
           }
           website.isVisible = value;
@@ -259,11 +263,12 @@ const store = {
         case 'firstParty':
           if ('firstParty' in website
               && website.firstParty === true) {
+            // once a website is a first party, it will always be drawn as one
             break;
           }
           website.firstParty = value;
           if (value) {
-            website.isVisible = true;
+            website.isVisible = value;
           }
           break;
         default:
@@ -273,6 +278,7 @@ const store = {
     }
 
     await this._write(website);
+
     return website;
   },
 


### PR DESCRIPTION
Dynamic vars were not updating correctly with the first party count in the switch statement for the `isVisible` and `firstParty` cases in `store.setWebsite`.