### PR TITLE
Throw away requests that are not in the default cookie store or reque…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
     "webRequest",
     "<all_urls>",
     "tabs",
+    "cookies",
     "storage",
     "downloads",
     "privacy"


### PR DESCRIPTION
…sts that we can't be certain what cookie store they are in

This patch throws away requests that we can't guarantee are not in default containers. This likely means that service workers will not be shown any more until we fix the browser.webRequest.* APIs to have cookieStoreId. Line 101 is this code which will likely break service worker page loads due to it being a non visible tab  which doesn't have a cookie jar assigned to it (in terms of the APIs anyway).

This function takes either a tab `browser.webRequest.onResponseStarted.addListener(` or `browser.tabs.onUpdated.addListener(` this allows us to capture the tab URL changes and web requests the page makes. Non visible tabs come through on webRequest.* apis which relate to internal code and service workers.

This I feel is better than letting users of Lightbeam think that containers are not isolated. Without this patch they will see one graph for all containers leading users to think they are tracked across a container boundary.

FYI: @biancadanforth, @groovecoder, @princiya (will notify Tanvi too)