### PR TITLE
Fix broken TP button

### DIFF
--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -23,10 +23,10 @@ const lightbeam = {
       trackingProtection.hidden = false;
       trackingProtectionDisabled.hidden = true;
 
-      const trackingProtection
+      const trackingProtectionState
         = await browser.privacy.websites.trackingProtectionMode.get({});
       let value = true;
-      if (trackingProtection.value !== 'always') {
+      if (trackingProtectionState.value !== 'always') {
         value = false;
       }
       toggleCheckbox.checked = value;


### PR DESCRIPTION
The tracking protection button is broken because we re-declare a const. This fixes it.