### PR TITLE
[WIP] Introducing web workers

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -654,3 +654,35 @@ footer.unimplemented {
   position: relative;
   z-index: 2;
 }
+
+#progress {
+  position: fixed;
+  top: 0;
+  left: -6px;
+  width: 0%;
+  height: 2px;
+  background: red;
+  z-index: 3;
+}
+
+#progress:before,
+#progress:after {
+  content: "";
+  position: absolute;
+  height: 2px;
+  opacity: 0.6;
+  box-shadow: red 1px 0 6px 1px;
+  border-radius: 100%;
+}
+
+#progress:before {
+  width: 20px;
+  right: 0;
+  clip: rect(-6px, 22px, 14px, 10px);
+}
+
+#progress:after {
+  width: 180px;
+  right: -80px;
+  clip: rect(-6px, 90px, 14px, -6px);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -99,6 +99,7 @@
         <div class="vis-content" id="visualization">
           <div id="tooltip"></div>
         </div>
+        <div id="progress"></div>
       </section>
       <footer class="unimplemented">
         <div class="footer-toggle unimplemented">

--- a/src/js/vizWorker.js
+++ b/src/js/vizWorker.js
@@ -1,0 +1,83 @@
+/* eslint-disable no-undef */
+importScripts('https://d3js.org/d3-collection.v1.min.js');
+importScripts('https://d3js.org/d3-dispatch.v1.min.js');
+importScripts('https://d3js.org/d3-quadtree.v1.min.js');
+importScripts('https://d3js.org/d3-timer.v1.min.js');
+importScripts('https://d3js.org/d3-force.v1.min.js');
+
+onmessage = (event) => {
+  d3Force.init(event.data);
+};
+
+const d3Force = {
+  init(data) {
+    const { nodes, links, width, height, subject } = data;
+    this.nodes = nodes;
+    this.links = links;
+    this.width = width;
+    this.height = height;
+    this.subject = subject;
+    d3Force.simulateForce();
+  },
+
+  simulateForce() {
+    if (!this.simulation) {
+      this.simulation = d3.forceSimulation(this.nodes);
+      this.simulation.on('tick', () => {
+        d3Force.simulateTick();
+      });
+      d3Force.registerSimulationForces();
+    } else {
+      this.simulation.nodes(this.nodes);
+      this.simulation.alpha(0.5);
+      this.simulation.restart();
+      // this.simulation.alpha(0);
+    }
+    d3Force.registerLinkForce();
+  },
+
+  simulateTick() {
+    const tickCounter = this.simulation.alpha();
+    postMessage({
+      type: 'tick',
+      progress: 1 - tickCounter
+    });
+    const tickPercent = Math.round((1 - tickCounter) * 100);
+    if (tickPercent === 99) {
+      if (this.subject) {
+        this.subject.fx = null;
+        this.subject.fy = null;
+        this.subject.xArr = null;
+        this.subject.yArr = null;
+      }
+      postMessage({
+        type: 'end',
+        nodes: d3Force.nodes,
+        links: d3Force.links
+      });
+    }
+  },
+
+  registerLinkForce() {
+    const linkForce = d3.forceLink(this.links);
+    linkForce.id((d) => d.hostname);
+    this.simulation.force('link', linkForce);
+  },
+
+  registerSimulationForces() {
+    const chargeStrength = -100,
+      collisionRadius = 10,
+      centerForce = d3.forceCenter(this.width / 2, this.height / 2),
+      forceX = d3.forceX(this.width / 2),
+      forceY = d3.forceY(this.height / 2),
+      chargeForce = d3.forceManyBody(),
+      collisionForce = d3.forceCollide(collisionRadius);
+
+    this.simulation.force('center', centerForce);
+    this.simulation.force('x', forceX);
+    this.simulation.force('y', forceY);
+    chargeForce.strength(chargeStrength);
+    this.simulation.force('charge', chargeForce);
+    this.simulation.force('collide', collisionForce);
+  }
+};


### PR DESCRIPTION
This is an initial attempt to improve the graph's performance for large no. of nodes.

Issue #232 

The idea in this PR is to off-load the heavy force layout computations to the web worker. This improves performance during page load.

I am also experimenting on passing the logic to web workers during the drag events. This part is still work in progress.

Here is the rough idea that I try to achieve:

![drag](http://g.recordit.co/y9y0prnWQH.gif)

In the present situation, when we drag, the force layout restarts the simulation. When there are large no. of nodes, the graph takes a lot of time to achieve equilibrium, thereby dropping the frame rates. Restarting the simulation is necessary, to compute the updated coordinates and give the soft transition, else the drag effect doesn't appear smooth.

Using web workers, I try to keep the dragged coordinates in the main thread, invoke the web worker during `dragEnd`. The web worker computes the updated coordinates and waits until the graph attains equilibrium. I need to figure a way to get the updated coordinates and achieve smooth animations.

cc @jonathanKingston @biancadanforth 